### PR TITLE
Updated template service to use templateEngine on options object

### DIFF
--- a/src/templateService.js
+++ b/src/templateService.js
@@ -25,16 +25,16 @@ module.exports = function (options) {
             if (options.provider.name === 'mandrill') {
                 layoutModel._unsubscribe = '*|HTML:unsubscribe_html|*';
             }
-            options.engine.render(options.layout, layoutModel, done);
+            options.templateEngine.render(options.layout, layoutModel, done);
         };
     }
 
     return {
         render: function (file, model, done) {
-            options.engine.render(file, model, getCallback(model, done));
+            options.templateEngine.render(file, model, getCallback(model, done));
         },
         renderString: function (template, model, done) {
-            options.engine.renderString(template, model, getCallback(model, done));
+            options.templateEngine.renderString(template, model, getCallback(model, done));
         }
     };
 };


### PR DESCRIPTION
I recently updated to version 1.4.4 and encountered an error that seems to be introduced when you streamlined the passing of the options object to the templateEngine.  The error is:

    node_modules/campaign/src/templateService.js:37
                options.engine.renderString(template, model, getCallback(model, do

It looks like the correct call is options.templateEngine.render or renderString based on the previous inputs.  I verified the error in your tests and then updated the code and retested with your tests passing.  

Thanks for a great client, appreciate the hard work!