### PR TITLE
Added Support badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![campaign.png][9] ![ga](https://ga-beacon.appspot.com/UA-35043128-6/campaign/readme?pixel)
 
 [![help me on gittip](http://gbindex.ssokolow.com/img/gittip-43x20.png)](https://www.gittip.com/bevacqua/) [![flattr.png](https://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=nzgb&url=https%3A%2F%2Fgithub.com%2Fbevacqua%2Fcampaign)
+[![Support](https://supporter.60devs.com/api/b/f4co3kmopd9mngbzjgn6ymbug/campaign)](https://supporter.60devs.com/support/f4co3kmopd9mngbzjgn6ymbug/campaign)
 
 > Compose responsive email templates easily, fill them with models, and send them out.
 


### PR DESCRIPTION
Hi @bevacqua,

this PR adds another badge for accepting donations. It's more friendly for one-time donations but supports recurring donations as well (and it's free). So it may work better than the other two badges. If you like the badge, you should sign in to the service website using your Github account and enter your PayPal address there to start accepting donations. It's also possible to change the goals and the description of the project. Our badge is also used by other open source projects, for example, JSPM and WDRL. 

If you don't like the idea of having an extra badge, please close this PR and I will remove the project page from our website.

Best regards and thanks for great open source projects,

Alex
co-creator of supporter.60devs.com